### PR TITLE
Turn off block validation if argument validate is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,9 @@ Blockchain.prototype._addBlock = function (block, cb) {
 
   async.series([
     function verify(cb2) {
+      if (!self.validate)
+        return cb2()
+
       block.validate(self, function (err) {
         cb2(err)
       })


### PR DESCRIPTION
Hey,

What do you think about turning off block validation if validate is false? I use the lib as an emulation of the real network, so I need some flag to disable that validation.